### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you want to support <iOS9 where UIStackView is not available, solution is to 
 
 Add the following to your `Podfile` and run `$ pod install`.
 
-Cocoapods support iOS9
+CocoaPods support iOS9
 
 ``` ruby
 pod 'INSStackViewForms'
@@ -86,7 +86,7 @@ pod 'INSStackViewForms'
 
 If you want to support <iOS9 where UIStackView is not available, solution is to use [OAStackView](https://github.com/oarrabi/OAStackView). I prepared subspec to make it easier.
 
-Cocoapods support <iOS9
+CocoaPods support <iOS9
 
 ``` ruby
 pod 'INSStackViewForms/OAStackView'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
